### PR TITLE
Patch multiple JSON exploits

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ This table details what patches have yet to be back-ported from both WNT's CFX a
 
 | Exploit                   | 1.14.x  | 1.15.x  | 1.16.x                                           | 1.17.x  | 1.18.x  | 1.19.x                                           | 1.20.x                | 
 |---------------------------|---------|---------|--------------------------------------------------|---------|---------|--------------------------------------------------|-----------------------|
-| **BadBlockEntityName**    | Not yet | Not yet | Not yet                                          | Not yet | Not yet | Not yet                                          | Not yet               |
-| **BadEntityName**         | Not yet | Not yet | Not yet                                          | Not yet | Not yet | Not yet                                          | Not yet               |
+| **BadBlockEntityName**    | v1_14   | v1_14   | v1_16                                            | N/A     | N/A     | N/A                                              | N/A                   |
+| **BadEntityName**         | v1_14   | v1_14   | N/A                                              | N/A     | N/A     | N/A                                              | N/A                   |
 | **BadHoverIdentifier**    | N/A     | N/A     | v1_16                                            | v1_16   | v1_16   | N/A                                              | N/A                   |
 | **BadHoverUUID**          | N/A     | N/A     | v1_16                                            | v1_16   | v1_16   | N/A                                              | N/A                   |
 | **BadSherdIdentifiers**   | N/A     | N/A     | N/A                                              | N/A     | N/A     | N/A                                              | v1_20 (1.20 - 1.20.1) |
@@ -17,7 +17,7 @@ This table details what patches have yet to be back-ported from both WNT's CFX a
 | **ExcessiveHearts**       | v1_14   | v1_14   | Not yet                                          | Not yet | Not yet | Not yet                                          | Not yet               |
 | **ExcessiveParticles**    | v1_14   | v1_14   | v1_14                                            | v1_14   | v1_14   | v1_14                                            | v1_14                 |
 | **ExtraComponentDepth**   | Not yet | Not yet | Not yet                                          | Not yet | Not yet | Not yet                                          | Not yet               |
-| **ExtraNestedArrays**     | Not yet | Not yet | Not yet                                          | Not yet | Not yet | Not yet                                          | Not yet               |
+| **ExtraNestedArrays**     | v1_14   | v1_14   | v1_16                                            | v1_16   | v1_16   | v1_16                                            | v1_16                 |
 | **NBTSize**               | v1_14   | v1_14   | v1_14                                            | v1_14   | v1_14   | v1_14 (1.19 - 1.19.2), v1_19_3 (1.19.3 - 1.19.4) | v1_19_3               |
 | **OutrageousTranslation** | Not yet | Not yet | Not yet                                          | v1_17   | v1_17   | v1_19                                            | v1_19                 |
 | **UndersizedHeads**       | Not yet | Not yet | Not yet                                          | N/A     | N/A     | N/A                                              | N/A                   |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This table details what patches have yet to be back-ported from both WNT's CFX a
 
 | Exploit                   | 1.14.x  | 1.15.x  | 1.16.x                                           | 1.17.x  | 1.18.x  | 1.19.x                                           | 1.20.x                | 
 |---------------------------|---------|---------|--------------------------------------------------|---------|---------|--------------------------------------------------|-----------------------|
+| **BadBlockEntityName**    | Not yet | Not yet | Not yet                                          | Not yet | Not yet | Not yet                                          | Not yet               |
+| **BadEntityName**         | Not yet | Not yet | Not yet                                          | Not yet | Not yet | Not yet                                          | Not yet               |
 | **BadHoverIdentifier**    | N/A     | N/A     | v1_16                                            | v1_16   | v1_16   | N/A                                              | N/A                   |
 | **BadHoverUUID**          | N/A     | N/A     | v1_16                                            | v1_16   | v1_16   | N/A                                              | N/A                   |
 | **BadSherdIdentifiers**   | N/A     | N/A     | N/A                                              | N/A     | N/A     | N/A                                              | v1_20 (1.20 - 1.20.1) |

--- a/src/main/java/me/videogamesm12/cfx/config/CFXConfig.java
+++ b/src/main/java/me/videogamesm12/cfx/config/CFXConfig.java
@@ -85,6 +85,8 @@ public class CFXConfig
 
     private Blocks blockPatches = new Blocks();
 
+    private Entities entityPatches = new Entities();
+
     private NBT nbtPatches = new NBT();
 
     private Network networkPatches = new Network();
@@ -117,6 +119,15 @@ public class CFXConfig
     public static class BlockEntities
     {
         private boolean potSherdValidationEnabled = true;
+
+        private boolean customNameValidationEnabled = true;
+    }
+
+    @Getter
+    @Setter
+    public static class Entities
+    {
+        private boolean customNameValidationEnabled = true;
     }
 
     @Getter
@@ -170,9 +181,18 @@ public class CFXConfig
     @Getter
     public static class Text
     {
+        private ExtraComponent extra = new ExtraComponent();
+
         private HoverEventComponent hoverEvent = new HoverEventComponent();
 
         private TranslatableComponent translation = new TranslatableComponent();
+
+        @Getter
+        @Setter
+        public static class ExtraComponent
+        {
+            private boolean emptyArrayPatchEnabled = true;
+        }
 
         @Getter
         @Setter

--- a/src/main/java/me/videogamesm12/cfx/config/CFXConfig.java
+++ b/src/main/java/me/videogamesm12/cfx/config/CFXConfig.java
@@ -41,7 +41,7 @@ public class CFXConfig
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
     private static final File file = new File(FabricLoader.getInstance().getConfigDir().toFile(), "cfx.json");
 
-    private static final int latestVersion = 2;
+    private static final int latestVersion = 3;
 
     public static CFXConfig load()
     {

--- a/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/BlockEntityPatches.java
+++ b/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/BlockEntityPatches.java
@@ -1,0 +1,38 @@
+package me.videogamesm12.cfx.v1_14.patches;
+
+import me.videogamesm12.cfx.CFX;
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.block.entity.LockableContainerBlockEntity;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+public class BlockEntityPatches
+{
+    @Mixin(LockableContainerBlockEntity.class)
+    @PatchMeta(minVersion = 477, maxVersion = 999)
+    public static class BadBlockEntityName
+    {
+        @ModifyArg(method = "fromTag", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/Text$Serializer;fromJson(Ljava/lang/String;)Lnet/minecraft/text/Text;"))
+        public String validateJson(String json)
+        {
+            if (CFX.getConfig().getBlockEntityPatches().isCustomNameValidationEnabled())
+            {
+                try
+                {
+                    Text.Serializer.fromJson(json);
+                    return json;
+                }
+                catch (Throwable ignored)
+                {
+                    return "";
+                }
+            }
+            else
+            {
+                return json;
+            }
+        }
+    }
+}

--- a/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/BlockEntityPatches.java
+++ b/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/BlockEntityPatches.java
@@ -11,7 +11,7 @@ import org.spongepowered.asm.mixin.injection.ModifyArg;
 public class BlockEntityPatches
 {
     @Mixin(LockableContainerBlockEntity.class)
-    @PatchMeta(minVersion = 477, maxVersion = 999)
+    @PatchMeta(minVersion = 477, maxVersion = 578) // 1.14 to 1.15.2
     public static class BadBlockEntityName
     {
         @ModifyArg(method = "fromTag", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/Text$Serializer;fromJson(Ljava/lang/String;)Lnet/minecraft/text/Text;"))

--- a/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/ComponentPatches.java
+++ b/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/ComponentPatches.java
@@ -36,7 +36,7 @@ public class ComponentPatches
     }
 
     @Mixin(Text.Serializer.class)
-    @PatchMeta(minVersion = 477, maxVersion = 999) // 1.14 to Latest
+    @PatchMeta(minVersion = 477, maxVersion = 578) // 1.14 to 1.15.2
     public static class ExtraEmptyArray
     {
         @Inject(method = "deserialize(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/text/Text;",

--- a/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/ComponentPatches.java
+++ b/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/ComponentPatches.java
@@ -1,5 +1,9 @@
 package me.videogamesm12.cfx.v1_14.patches;
 
+import com.google.gson.JsonArray;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParseException;
 import me.videogamesm12.cfx.CFX;
 import me.videogamesm12.cfx.management.PatchMeta;
 import net.minecraft.text.LiteralText;
@@ -9,6 +13,8 @@ import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+import java.lang.reflect.Type;
 
 public class ComponentPatches
 {
@@ -25,6 +31,25 @@ public class ComponentPatches
             if (CFX.getConfig().getTextPatches().getTranslation().isBoundaryPatchEnabled() && index < 0)
             {
                 cir.setReturnValue(new LiteralText("null"));
+            }
+        }
+    }
+
+    @Mixin(Text.Serializer.class)
+    @PatchMeta(minVersion = 477, maxVersion = 999) // 1.14 to Latest
+    public static class ExtraEmptyArray
+    {
+        @Inject(method = "deserialize(Lcom/google/gson/JsonElement;Ljava/lang/reflect/Type;Lcom/google/gson/JsonDeserializationContext;)Lnet/minecraft/text/Text;",
+                at = @At(value = "INVOKE",
+                        target = "Lcom/google/gson/JsonElement;getAsJsonArray()Lcom/google/gson/JsonArray;",
+                        shift = At.Shift.AFTER))
+        public void patchEmptyArray(JsonElement jsonElement, Type type, JsonDeserializationContext jsonDeserializationContext, CallbackInfoReturnable<Text> cir)
+        {
+            final JsonArray array = jsonElement.getAsJsonArray();
+
+            if (CFX.getConfig().getTextPatches().getExtra().isEmptyArrayPatchEnabled() && array.size() <= 0)
+            {
+                throw new JsonParseException("Unexpected empty array of components");
             }
         }
     }

--- a/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/EntityPatches.java
+++ b/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/EntityPatches.java
@@ -1,0 +1,38 @@
+package me.videogamesm12.cfx.v1_14.patches;
+
+import me.videogamesm12.cfx.CFX;
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.entity.Entity;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
+
+public class EntityPatches
+{
+    @Mixin(Entity.class)
+    @PatchMeta(minVersion = 477, maxVersion = 999)
+    public static class BadEntityName
+    {
+        @ModifyArg(method = "fromTag", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/Text$Serializer;fromJson(Ljava/lang/String;)Lnet/minecraft/text/Text;"))
+        public String validateJson(String json)
+        {
+            if (CFX.getConfig().getEntityPatches().isCustomNameValidationEnabled())
+            {
+                try
+                {
+                    Text.Serializer.fromJson(json);
+                    return json;
+                }
+                catch (Throwable ignored)
+                {
+                    return "";
+                }
+            }
+            else
+            {
+                return json;
+            }
+        }
+    }
+}

--- a/v1_14/src/main/resources/cfx.v1_14.mixins.json
+++ b/v1_14/src/main/resources/cfx.v1_14.mixins.json
@@ -13,7 +13,10 @@
     "RendererPatches$HudPatches$ExcessiveHearts"
   ],
   "mixins": [
+    "BlockEntityPatches$BadBlockEntityName",
     "ComponentPatches$BoundlessTranslation",
+    "ComponentPatches$ExtraEmptyArray",
+    "EntityPatches$BadEntityName",
     "NbtPatches$NBTSize"
   ]
 }

--- a/v1_16/src/main/java/me/videogamesm12/cfx/v1_16/patches/BlockEntityPatches.java
+++ b/v1_16/src/main/java/me/videogamesm12/cfx/v1_16/patches/BlockEntityPatches.java
@@ -1,23 +1,23 @@
-package me.videogamesm12.cfx.v1_14.patches;
+package me.videogamesm12.cfx.v1_16.patches;
 
 import me.videogamesm12.cfx.CFX;
 import me.videogamesm12.cfx.management.PatchMeta;
-import net.minecraft.entity.Entity;
+import net.minecraft.block.entity.LockableContainerBlockEntity;
 import net.minecraft.text.Text;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
-public class EntityPatches
+public class BlockEntityPatches
 {
-    @Mixin(Entity.class)
-    @PatchMeta(minVersion = 477, maxVersion = 578) // 1.14 to 1.15.2
-    public static class BadEntityName
+    @Mixin(LockableContainerBlockEntity.class)
+    @PatchMeta(minVersion = 735, maxVersion = 754) // 1.16 to 1.16.5
+    public static class BadBlockEntityName
     {
-        @ModifyArg(method = "fromTag", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/Text$Serializer;fromJson(Ljava/lang/String;)Lnet/minecraft/text/Text;"))
+        @ModifyArg(method = "fromTag", at = @At(value = "INVOKE", target = "Lnet/minecraft/text/Text$Serializer;fromJson(Ljava/lang/String;)Lnet/minecraft/text/MutableText;"))
         public String validateJson(String json)
         {
-            if (CFX.getConfig().getEntityPatches().isCustomNameValidationEnabled())
+            if (CFX.getConfig().getBlockEntityPatches().isCustomNameValidationEnabled())
             {
                 try
                 {

--- a/v1_16/src/main/resources/cfx.v1_16.mixins.json
+++ b/v1_16/src/main/resources/cfx.v1_16.mixins.json
@@ -11,9 +11,11 @@
     "RendererPatches$EntityPatches$ExcessiveEntityNames"
   ],
   "mixins": [
+    "BlockEntityPatches$BadBlockEntityName",
     "ComponentPatches$BadEntityHoverIdentifier",
     "ComponentPatches$BadEntityHoverUUID",
     "ComponentPatches$BadItemHoverIdentifier",
-    "ComponentPatches$BoundlessTranslation"
+    "ComponentPatches$BoundlessTranslation",
+    "ComponentPatches$ExtraEmptyArray"
   ]
 }


### PR DESCRIPTION
This commit patches three exploits, which are all JSON related:

* BadBlockEntityName (1.14 to 1.16.5)
* BadEntityName (1.14 to 1.15.2)
* ExtraNestedArrays (1.14 to 1.20.1)