### PR TITLE
Patches UndersizedHeads for affected versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,22 +11,22 @@ So, this is where CFX steps in. It tries to patch some of the more hazardous exp
 ## Patch Coverage
 This table details what patches have yet to be back-ported from both WNT's CFX and Cockblocker.
 
-| Exploit                   | 1.14.x  | 1.15.x  | 1.16.x                                           | 1.17.x  | 1.18.x  | 1.19.x                                                             | 1.20.x                | 
-|---------------------------|---------|---------|--------------------------------------------------|---------|---------|--------------------------------------------------------------------|-----------------------|
-| **BadBlockEntityName**    | v1_14   | v1_14   | v1_16                                            | N/A     | N/A     | N/A                                                                | N/A                   |
-| **BadEntityName**         | v1_14   | v1_14   | N/A                                              | N/A     | N/A     | N/A                                                                | N/A                   |
-| **BadHoverIdentifier**    | N/A     | N/A     | v1_16                                            | v1_16   | v1_16   | N/A                                                                | N/A                   |
-| **BadHoverUUID**          | N/A     | N/A     | v1_16                                            | v1_16   | v1_16   | N/A                                                                | N/A                   |
-| **BadSherdIdentifiers**   | N/A     | N/A     | N/A                                              | N/A     | N/A     | N/A                                                                | v1_20 (1.20 - 1.20.1) |
-| **BoundlessTranslation**  | v1_14   | v1_14   | v1_16 (1.16 - 1.16.1), v1_16_2 (1.16.2 - 1.16.5) | v1_16_2 | v1_16_2 | v1_19 (1.19 - 1.19.2)                                              | N/A                   |
-| **ClickableCommands**     | v1_14   | v1_14   | v1_16                                            | v1_16   | v1_16   | v1_19 (1.19), v1_19_1 (1.19.1 - 1.19.2), v1_19_3 (1.19.3 - 1.19.4) | v1_19_3               |
-| **CommandSigns**          | v1_14   | v1_14   | v1_14                                            | v1_17   | v1_17   | v1_19                                                              | v1_20                 |
-| **ComponentDepth**        | v1_14   | v1_14   | v1_16                                            | v1_16   | v1_16   | v1_19                                                              | v1_19                 |
-| **ExcessiveEntityNames**  | v1_14   | v1_15   | v1_16                                            | v1_16   | v1_16   | v1_19                                                              | v1_19                 |
-| **ExcessiveHearts**       | v1_14   | v1_14   | v1_16                                            | v1_16   | v1_16   | v1_16                                                              | Not yet               |
-| **ExcessiveParticles**    | v1_14   | v1_14   | v1_14                                            | v1_14   | v1_14   | v1_14                                                              | v1_14                 |
-| **ExtraNestedArrays**     | v1_14   | v1_14   | v1_16                                            | v1_16   | v1_16   | v1_16                                                              | v1_16                 |
-| **NBTSize**               | v1_14   | v1_14   | v1_14                                            | v1_14   | v1_14   | v1_14 (1.19 - 1.19.2), v1_19_3 (1.19.3 - 1.19.4)                   | v1_19_3               |
-| **OutrageousTranslation** | v1_14   | v1_14   | v1_16                                            | v1_17   | v1_17   | v1_19                                                              | v1_19                 |
-| **UndersizedHeads**       | Not yet | Not yet | Not yet                                          | N/A     | N/A     | N/A                                                                | N/A                   |
-| **UpsideDownPortals**     | N/A     | N/A     | v1_16_2 (1.16.2 - 1.16.4)                        | N/A     | N/A     | N/A                                                                | N/A                   |
+| Exploit                   | 1.14.x | 1.15.x | 1.16.x                                           | 1.17.x  | 1.18.x  | 1.19.x                                                             | 1.20.x                | 
+|---------------------------|--------|--------|--------------------------------------------------|---------|---------|--------------------------------------------------------------------|-----------------------|
+| **BadBlockEntityName**    | v1_14  | v1_14  | v1_16                                            | N/A     | N/A     | N/A                                                                | N/A                   |
+| **BadEntityName**         | v1_14  | v1_14  | N/A                                              | N/A     | N/A     | N/A                                                                | N/A                   |
+| **BadHoverIdentifier**    | N/A    | N/A    | v1_16                                            | v1_16   | v1_16   | N/A                                                                | N/A                   |
+| **BadHoverUUID**          | N/A    | N/A    | v1_16                                            | v1_16   | v1_16   | N/A                                                                | N/A                   |
+| **BadSherdIdentifiers**   | N/A    | N/A    | N/A                                              | N/A     | N/A     | N/A                                                                | v1_20 (1.20 - 1.20.1) |
+| **BoundlessTranslation**  | v1_14  | v1_14  | v1_16 (1.16 - 1.16.1), v1_16_2 (1.16.2 - 1.16.5) | v1_16_2 | v1_16_2 | v1_19 (1.19 - 1.19.2)                                              | N/A                   |
+| **ClickableCommands**     | v1_14  | v1_14  | v1_16                                            | v1_16   | v1_16   | v1_19 (1.19), v1_19_1 (1.19.1 - 1.19.2), v1_19_3 (1.19.3 - 1.19.4) | v1_19_3               |
+| **CommandSigns**          | v1_14  | v1_14  | v1_14                                            | v1_17   | v1_17   | v1_19                                                              | v1_20                 |
+| **ComponentDepth**        | v1_14  | v1_14  | v1_16                                            | v1_16   | v1_16   | v1_19                                                              | v1_19                 |
+| **ExcessiveEntityNames**  | v1_14  | v1_15  | v1_16                                            | v1_16   | v1_16   | v1_19                                                              | v1_19                 |
+| **ExcessiveHearts**       | v1_14  | v1_14  | v1_16                                            | v1_16   | v1_16   | v1_16                                                              | Not yet               |
+| **ExcessiveParticles**    | v1_14  | v1_14  | v1_14                                            | v1_14   | v1_14   | v1_14                                                              | v1_14                 |
+| **ExtraNestedArrays**     | v1_14  | v1_14  | v1_16                                            | v1_16   | v1_16   | v1_16                                                              | v1_16                 |
+| **NBTSize**               | v1_14  | v1_14  | v1_14                                            | v1_14   | v1_14   | v1_14 (1.19 - 1.19.2), v1_19_3 (1.19.3 - 1.19.4)                   | v1_19_3               |
+| **OutrageousTranslation** | v1_14  | v1_14  | v1_16                                            | v1_17   | v1_17   | v1_19                                                              | v1_19                 |
+| **UndersizedHeads**       | v1_14  | v1_15  | v1_15                                            | N/A     | N/A     | N/A                                                                | N/A                   |
+| **UpsideDownPortals**     | N/A    | N/A    | v1_16_2 (1.16.2 - 1.16.4)                        | N/A     | N/A     | N/A                                                                | N/A                   |

--- a/src/main/java/me/videogamesm12/cfx/config/CFXConfig.java
+++ b/src/main/java/me/videogamesm12/cfx/config/CFXConfig.java
@@ -43,7 +43,7 @@ public class CFXConfig
     private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
     private static final File file = new File(FabricLoader.getInstance().getConfigDir().toFile(), "cfx.json");
 
-    private static final int latestVersion = 7;
+    private static final int latestVersion = 8;
 
     public static CFXConfig load()
     {
@@ -95,6 +95,8 @@ public class CFXConfig
     private Network networkPatches = new Network();
 
     private Render renderPatches = new Render();
+
+    private Resources resourcePatches = new Resources();
 
     private Text textPatches = new Text();
 
@@ -181,6 +183,19 @@ public class CFXConfig
         public boolean areSensitivePatchesAllowed()
         {
             return sensitivePatchesAllowed;
+        }
+    }
+
+    @Getter
+    public static class Resources
+    {
+        private PlayerSkins playerSkins = new PlayerSkins();
+
+        @Getter
+        @Setter
+        public static class PlayerSkins
+        {
+            private boolean minimumSkinResolutionEnforcementEnabled = true;
         }
     }
 

--- a/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/individual/UndersizedHeads.java
+++ b/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/individual/UndersizedHeads.java
@@ -1,0 +1,41 @@
+package me.videogamesm12.cfx.v1_14.patches.individual;
+
+import me.videogamesm12.cfx.CFX;
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.texture.NativeImage;
+import net.minecraft.client.texture.PlayerSkinTexture;
+import net.minecraft.client.texture.ResourceTexture;
+import net.minecraft.client.texture.SkinRemappingImageFilter;
+import net.minecraft.client.util.DefaultSkinHelper;
+import net.minecraft.resource.ReloadableResourceManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(SkinRemappingImageFilter.class)
+@PatchMeta(minVersion = 477, maxVersion = 498) // 1.14 to 1.14.4
+public class UndersizedHeads
+{
+    @ModifyVariable(method = "filterImage", at = @At("HEAD"), argsOnly = true)
+    private NativeImage enforceMinimumImageSize(NativeImage image)
+    {
+        if (CFX.getConfig().getResourcePatches().getPlayerSkins().isMinimumSkinResolutionEnforcementEnabled()
+                && image.getHeight() < 32 || image.getWidth() < 64)
+        {
+            final ReloadableResourceManager rm = (ReloadableResourceManager) MinecraftClient.getInstance().getResourceManager();
+            final ResourceTexture.TextureData data = ResourceTexture.TextureData.load(rm, DefaultSkinHelper.getTexture());
+
+            try
+            {
+                return data.getImage();
+            }
+            catch (Exception ex)
+            {
+                ex.printStackTrace();
+            }
+        }
+
+        return image;
+    }
+}

--- a/v1_14/src/main/resources/cfx.v1_14.mixins.json
+++ b/v1_14/src/main/resources/cfx.v1_14.mixins.json
@@ -10,7 +10,8 @@
   "client": [
     "NetworkPatches$ClientBoundPatches$ExcessiveParticles",
     "RendererPatches$EntityPatches$ExcessiveEntityNames",
-    "RendererPatches$HudPatches$ExcessiveHearts"
+    "RendererPatches$HudPatches$ExcessiveHearts",
+    "individual.UndersizedHeads"
   ],
   "mixins": [
     "BlockEntityPatches$BadBlockEntityName",

--- a/v1_15/src/main/java/me/videogamesm12/cfx/v1_15/patches/individual/UndersizedHeads.java
+++ b/v1_15/src/main/java/me/videogamesm12/cfx/v1_15/patches/individual/UndersizedHeads.java
@@ -1,0 +1,40 @@
+package me.videogamesm12.cfx.v1_15.patches.individual;
+
+import me.videogamesm12.cfx.CFX;
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.texture.NativeImage;
+import net.minecraft.client.texture.PlayerSkinTexture;
+import net.minecraft.client.texture.ResourceTexture;
+import net.minecraft.client.util.DefaultSkinHelper;
+import net.minecraft.resource.ReloadableResourceManager;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyVariable;
+
+@Mixin(PlayerSkinTexture.class)
+@PatchMeta(minVersion = 573, maxVersion = 754) // 1.15 to 1.16.5
+public class UndersizedHeads
+{
+    @ModifyVariable(method = "remapTexture", at = @At("HEAD"), argsOnly = true)
+    private static NativeImage enforceMinimumImageSize(NativeImage image)
+    {
+        if (CFX.getConfig().getResourcePatches().getPlayerSkins().isMinimumSkinResolutionEnforcementEnabled()
+                && image.getHeight() < 32 || image.getWidth() < 64)
+        {
+            final ReloadableResourceManager rm = (ReloadableResourceManager) MinecraftClient.getInstance().getResourceManager();
+            final ResourceTexture.TextureData data = ResourceTexture.TextureData.load(rm, DefaultSkinHelper.getTexture());
+
+            try
+            {
+                return data.getImage();
+            }
+            catch (Exception ex)
+            {
+                ex.printStackTrace();
+            }
+        }
+
+        return image;
+    }
+}

--- a/v1_15/src/main/resources/cfx.v1_15.mixins.json
+++ b/v1_15/src/main/resources/cfx.v1_15.mixins.json
@@ -8,6 +8,7 @@
     "defaultRequire": 1
   },
   "client": [
-    "RendererPatches$EntityPatches$ExcessiveEntityNames"
+    "RendererPatches$EntityPatches$ExcessiveEntityNames",
+    "individual.UndersizedHeads"
   ]
 }


### PR DESCRIPTION
This resolves #5 by patching the exploit for versions 1.14 to 1.16.5.