### PR TITLE
Adds client-side equivalent of CommandSigns patch

### DIFF
--- a/src/main/resources/assets/cfx/lang/en_us.json
+++ b/src/main/resources/assets/cfx/lang/en_us.json
@@ -1,7 +1,12 @@
 {
   "cfx.command.reload.success": "Successfully reloaded CFX's configuration",
-  
+
+  "cfx.error.not_executing_as_sign_changed": "Sign data changed since original prompt, command execution aborted",
+  "cfx.error.not_executing_as_player_direction_changed": "Player is no longer facing the right way since original prompt, command execution aborted",
+  "cfx.error.not_executing_as_sign_broke": "Sign was broken or replaced with different type since original prompt, command execution aborted",
+
   "cfx.prompt.run_command": "Are you sure you want to run this command?",
+  "cfx.prompt.run_commands": "Are you sure you want to run these commands?",
 
   "cfx.replacement.too_complex": "*** Component is too complex ***",
   "cfx.replacement.too_many_placeholders": "*** Component has too many placeholders ***"

--- a/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/CommandSignsTwo.java
+++ b/v1_14/src/main/java/me/videogamesm12/cfx/v1_14/patches/CommandSignsTwo.java
@@ -1,0 +1,120 @@
+package me.videogamesm12.cfx.v1_14.patches;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.videogamesm12.cfx.CFX;
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Mixin(MinecraftClient.class)
+@PatchMeta(minVersion = 477, maxVersion = 578)
+public abstract class CommandSignsTwo
+{
+	@Shadow public abstract void openScreen(Screen par1);
+
+	@WrapOperation(method= "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;interactBlock(Lnet/minecraft/client/network/ClientPlayerEntity;Lnet/minecraft/client/world/ClientWorld;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;"))
+	public ActionResult verify(ClientPlayerInteractionManager instance, ClientPlayerEntity player, ClientWorld world,
+							   Hand hand, BlockHitResult hitResult, Operation<ActionResult> original)
+	{
+		if (world != null && world.getBlockEntity(hitResult.getBlockPos()) != null
+				&& world.getBlockEntity(hitResult.getBlockPos()) instanceof SignBlockEntity)
+		{
+			SignBlockEntity sign = Objects.requireNonNull((SignBlockEntity) world.getBlockEntity(hitResult.getBlockPos()));
+
+			switch (CFX.getConfig().getTextPatches().getClickEvent().getCommandClickClientMode())
+			{
+				case NOTIFY:
+				{
+					final List<String> commands = cfx$getComponentsFromSign(sign).stream().filter(text -> text.getStyle().getClickEvent() != null
+							&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).collect(Collectors.toList());
+
+					// No commands to execute, just move on
+					if (commands.isEmpty())
+					{
+						return original.call(instance, player, world, hand, hitResult);
+					}
+
+					openScreen(new ConfirmScreen((bool) -> {
+						if (bool)
+						{
+							// -- Integrity checks to prevent switcheroos --
+
+							// We will refuse to execute if:
+							// 	* The sign is not loaded or no longer exists
+							//	* The commands on the side of the sign have since changed
+							if (world.getBlockEntity(hitResult.getBlockPos()) == null)
+							{
+								player.sendMessage(new TranslatableText("cfx.error.not_executing_as_sign_broke").formatted(Formatting.RED));
+								openScreen(null);
+								return;
+							}
+
+							// Zero tolerance for changes
+							SignBlockEntity sign2 = (SignBlockEntity) world.getBlockEntity(hitResult.getBlockPos());
+							List<String> commands2 = cfx$getComponentsFromSign(sign2).stream().filter(text -> text.getStyle().getClickEvent() != null
+									&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).collect(Collectors.toList());
+
+							if (!commands.equals(commands2))
+							{
+								player.sendMessage(new TranslatableText("cfx.error.not_executing_as_sign_changed").formatted(Formatting.RED));
+								openScreen(null);
+								return;
+							}
+
+							original.call(instance, player, world, hand, hitResult);
+						}
+						openScreen(null);
+					}, new TranslatableText("cfx.prompt.run_command" + (commands.size() > 1 ? "s" : "")),
+							new LiteralText(String.join("\n", commands))));
+				}
+				case DO_NOTHING:
+				{
+					return ActionResult.FAIL;
+				}
+				default:
+				{
+					return original.call(instance, player, world, hand, hitResult);
+				}
+			}
+		}
+		else
+		{
+			return original.call(instance, player, world, hand, hitResult);
+		}
+	}
+
+	@Unique
+	private List<Text> cfx$getComponentsFromSign(SignBlockEntity sign)
+	{
+		final List<Text> lines = new ArrayList<>();
+		for (int i = 0; i < 4; i++)
+		{
+			lines.add(sign.getTextOnRow(i));
+		}
+
+		return lines;
+	}
+}

--- a/v1_14/src/main/resources/cfx.v1_14.mixins.json
+++ b/v1_14/src/main/resources/cfx.v1_14.mixins.json
@@ -9,6 +9,7 @@
   },
   "client": [
     "ClientClickableCommand",
+    "CommandSignsTwo",
     "ExcessiveEntityNames",
     "ExcessiveHearts",
     "ExcessiveParticles",

--- a/v1_16/src/main/java/me/videogamesm12/cfx/v1_16/patches/CommandSignsTwo.java
+++ b/v1_16/src/main/java/me/videogamesm12/cfx/v1_16/patches/CommandSignsTwo.java
@@ -1,0 +1,115 @@
+package me.videogamesm12.cfx.v1_16.patches;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.videogamesm12.cfx.CFX;
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.LiteralText;
+import net.minecraft.text.Text;
+import net.minecraft.text.TranslatableText;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+@Mixin(MinecraftClient.class)
+@PatchMeta(minVersion = 735, maxVersion = 758)
+public abstract class CommandSignsTwo
+{
+	@Shadow public abstract void openScreen(Screen par1);
+
+	@WrapOperation(method= "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;interactBlock(Lnet/minecraft/client/network/ClientPlayerEntity;Lnet/minecraft/client/world/ClientWorld;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;"))
+	public ActionResult verify(ClientPlayerInteractionManager instance, ClientPlayerEntity player, ClientWorld world,
+							   Hand hand, BlockHitResult hitResult, Operation<ActionResult> original)
+	{
+		if (world != null && world.getBlockEntity(hitResult.getBlockPos()) != null
+				&& world.getBlockEntity(hitResult.getBlockPos()) instanceof SignBlockEntity)
+		{
+			SignBlockEntity sign = Objects.requireNonNull((SignBlockEntity) world.getBlockEntity(hitResult.getBlockPos()));
+
+			switch (CFX.getConfig().getTextPatches().getClickEvent().getCommandClickClientMode())
+			{
+				case NOTIFY:
+				{
+					final List<String> commands = cfx$getComponentsFromSign(sign).stream().filter(text -> text.getStyle().getClickEvent() != null
+							&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).collect(Collectors.toList());
+
+					// No commands to execute, just move on
+					if (commands.isEmpty())
+					{
+						return original.call(instance, player, world, hand, hitResult);
+					}
+
+					openScreen(new ConfirmScreen((bool) -> {
+						if (bool)
+						{
+							// -- Integrity checks to prevent switcheroos --
+
+							// We will refuse to execute if:
+							// 	* The sign is not loaded or no longer exists
+							//	* The commands on the side of the sign have since changed
+							if (world.getBlockEntity(hitResult.getBlockPos()) == null)
+							{
+								player.sendMessage(new TranslatableText("cfx.error.not_executing_as_sign_broke").formatted(Formatting.RED), false);
+								openScreen(null);
+								return;
+							}
+
+							// Zero tolerance for changes
+							SignBlockEntity sign2 = (SignBlockEntity) world.getBlockEntity(hitResult.getBlockPos());
+							List<String> commands2 = cfx$getComponentsFromSign(sign2).stream().filter(text -> text.getStyle().getClickEvent() != null
+									&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).collect(Collectors.toList());
+
+							if (!commands.equals(commands2))
+							{
+								player.sendMessage(new TranslatableText("cfx.error.not_executing_as_sign_changed").formatted(Formatting.RED), false);
+								openScreen(null);
+								return;
+							}
+
+							original.call(instance, player, world, hand, hitResult);
+						}
+						openScreen(null);
+					}, new TranslatableText("cfx.prompt.run_command" + (commands.size() > 1 ? "s" : "")),
+							new LiteralText(String.join("\n", commands))));
+				}
+				case DO_NOTHING:
+				{
+					return ActionResult.FAIL;
+				}
+				default:
+				{
+					return original.call(instance, player, world, hand, hitResult);
+				}
+			}
+		}
+		else
+		{
+			return original.call(instance, player, world, hand, hitResult);
+		}
+	}
+
+	@Unique
+	private List<Text> cfx$getComponentsFromSign(SignBlockEntity sign)
+	{
+		return Arrays.asList(((SignBlockEntityAccessor) sign).getText());
+	}
+}

--- a/v1_16/src/main/java/me/videogamesm12/cfx/v1_16/patches/SignBlockEntityAccessor.java
+++ b/v1_16/src/main/java/me/videogamesm12/cfx/v1_16/patches/SignBlockEntityAccessor.java
@@ -1,0 +1,15 @@
+package me.videogamesm12.cfx.v1_16.patches;
+
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.text.Text;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Accessor;
+
+@Mixin(SignBlockEntity.class)
+@PatchMeta(minVersion = 735, maxVersion = 758)
+public interface SignBlockEntityAccessor
+{
+	@Accessor
+	Text[] getText();
+}

--- a/v1_16/src/main/resources/cfx.v1_16.mixins.json
+++ b/v1_16/src/main/resources/cfx.v1_16.mixins.json
@@ -9,6 +9,7 @@
   },
   "client": [
     "ClientClickableCommand",
+    "CommandSignsTwo",
     "ExcessiveEntityNames",
     "ExcessiveHearts"
   ],
@@ -20,6 +21,7 @@
     "BoundlessTranslation",
     "ComponentDepth",
     "ExtraEmptyArray",
-    "OutrageousTranslation"
+    "OutrageousTranslation",
+    "SignBlockEntityAccessor"
   ]
 }

--- a/v1_19/src/main/java/me/videogamesm12/cfx/v1_19/patches/CommandSignsTwo.java
+++ b/v1_19/src/main/java/me/videogamesm12/cfx/v1_19/patches/CommandSignsTwo.java
@@ -1,0 +1,119 @@
+package me.videogamesm12.cfx.v1_19.patches;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.videogamesm12.cfx.CFX;
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.Unique;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Mixin(MinecraftClient.class)
+@PatchMeta(minVersion = 759, maxVersion = 762)
+public abstract class CommandSignsTwo
+{
+	@Shadow @Nullable public ClientWorld world;
+
+	@Shadow public abstract void setScreen(Screen par1);
+
+	@Shadow public abstract boolean shouldFilterText();
+
+	@WrapOperation(method= "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;interactBlock(Lnet/minecraft/client/network/ClientPlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;"))
+	public ActionResult verify(ClientPlayerInteractionManager instance, ClientPlayerEntity clientPlayerEntity, Hand hand,
+							   BlockHitResult blockHitResult, Operation<ActionResult> original)
+	{
+		if (world != null && world.getBlockEntity(blockHitResult.getBlockPos()) != null
+				&& world.getBlockEntity(blockHitResult.getBlockPos()) instanceof SignBlockEntity sign)
+		{
+			switch (CFX.getConfig().getTextPatches().getClickEvent().getCommandClickClientMode())
+			{
+				case NOTIFY ->
+				{
+					final List<String> commands = cfx$getComponentsFromSign(sign).stream().filter(text -> text.getStyle().getClickEvent() != null
+							&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).toList();
+
+					// This is the deal as we knew it when we clicked the sign.
+					final BlockEntityType<?> type = sign.getType();
+
+					setScreen(new ConfirmScreen((bool) -> {
+						if (bool)
+						{
+							// -- Integrity checks to prevent switcheroos --
+
+							// We will refuse to execute if:
+							// 	* The sign is not loaded or no longer exists
+							//	* The commands on the side of the sign have since changed
+							if (world.getBlockEntity(blockHitResult.getBlockPos(), type).isEmpty())
+							{
+								clientPlayerEntity.sendMessage(Text.translatable("cfx.error.not_executing_as_sign_broke").formatted(Formatting.RED));
+								setScreen(null);
+								return;
+							}
+
+							// Zero tolerance for changes
+							SignBlockEntity sign2 = (SignBlockEntity) world.getBlockEntity(blockHitResult.getBlockPos());
+							List<String> commands2 = cfx$getComponentsFromSign(sign2).stream().filter(text -> text.getStyle().getClickEvent() != null
+									&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).toList();
+
+							if (!commands.equals(commands2))
+							{
+								clientPlayerEntity.sendMessage(Text.translatable("cfx.error.not_executing_as_sign_changed").formatted(Formatting.RED));
+								setScreen(null);
+								return;
+							}
+
+							original.call(instance, clientPlayerEntity, hand, blockHitResult);
+						}
+						setScreen(null);
+					}, Text.translatable("cfx.prompt.run_command" + (commands.size() > 1 ? "s" : "")),
+							Text.literal(String.join("\n", commands))));
+
+					return ActionResult.SUCCESS;
+				}
+				case DO_NOTHING ->
+				{
+					return ActionResult.FAIL;
+				}
+				default ->
+				{
+					return original.call(instance, clientPlayerEntity, hand, blockHitResult);
+				}
+			}
+		}
+		else
+		{
+			return original.call(instance, clientPlayerEntity, hand, blockHitResult);
+		}
+	}
+
+	@Unique
+	private List<Text> cfx$getComponentsFromSign(SignBlockEntity sign)
+	{
+		final List<Text> lines = new ArrayList<>();
+		for (int i = 0; i < 4; i++)
+		{
+			lines.add(sign.getTextOnRow(i, shouldFilterText()));
+		}
+
+		return lines;
+	}
+}

--- a/v1_19/src/main/resources/cfx.v1_19.mixins.json
+++ b/v1_19/src/main/resources/cfx.v1_19.mixins.json
@@ -9,6 +9,7 @@
   },
   "client": [
     "ClientClickableCommand",
+    "CommandSignsTwo",
     "ExcessiveEntityNames"
   ],
   "mixins": [

--- a/v1_20/src/main/java/me/videogamesm12/cfx/v1_20/patches/CommandSigns.java
+++ b/v1_20/src/main/java/me/videogamesm12/cfx/v1_20/patches/CommandSigns.java
@@ -40,7 +40,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
  */
 @Mixin(SignBlockEntity.class)
 @PatchMeta(minVersion = 763, maxVersion = 764) // 1.20 to 1.20.2
-public class ClickableCommandSign
+public class CommandSigns
 {
     @Inject(method = "runCommandClickEvent",
             at = @At(value = "INVOKE",

--- a/v1_20/src/main/java/me/videogamesm12/cfx/v1_20/patches/CommandSignsTwo.java
+++ b/v1_20/src/main/java/me/videogamesm12/cfx/v1_20/patches/CommandSignsTwo.java
@@ -1,0 +1,115 @@
+package me.videogamesm12.cfx.v1_20.patches;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.videogamesm12.cfx.CFX;
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@Mixin(MinecraftClient.class)
+@PatchMeta(minVersion = 763, maxVersion = 767)
+public abstract class CommandSignsTwo
+{
+	@Shadow @Nullable public ClientWorld world;
+
+	@Shadow public abstract void setScreen(Screen par1);
+
+	@WrapOperation(method= "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;interactBlock(Lnet/minecraft/client/network/ClientPlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;"))
+	public ActionResult verify(ClientPlayerInteractionManager instance, ClientPlayerEntity clientPlayerEntity, Hand hand,
+							   BlockHitResult blockHitResult, Operation<ActionResult> original)
+	{
+		if (world != null && world.getBlockEntity(blockHitResult.getBlockPos()) != null
+				&& world.getBlockEntity(blockHitResult.getBlockPos()) instanceof SignBlockEntity sign
+				&& sign.getText(sign.isPlayerFacingFront(clientPlayerEntity)).hasRunCommandClickEvent(clientPlayerEntity))
+		{
+			switch (CFX.getConfig().getTextPatches().getClickEvent().getCommandClickClientMode())
+			{
+				case NOTIFY ->
+				{
+					final List<String> commands = Arrays.stream(sign.getText(sign.isPlayerFacingFront(clientPlayerEntity)).getMessages(clientPlayerEntity.shouldFilterText())).filter(text -> text.getStyle().getClickEvent() != null
+							&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).toList();
+
+					// This is the deal as we knew it when we clicked the sign.
+					final BlockEntityType<?> type = sign.getType();
+					final boolean playerIsFacingFront = sign.isPlayerFacingFront(clientPlayerEntity);
+
+					setScreen(new ConfirmScreen((bool) -> {
+						if (bool)
+						{
+							// -- Integrity checks to prevent switcheroos --
+
+							// We will refuse to execute if:
+							//	* The player is no longer facing the sign in question
+							// 	* The sign is not loaded or no longer exists
+							//	* The commands on the side of the sign have since changed
+							if (playerIsFacingFront != sign.isPlayerFacingFront(clientPlayerEntity))
+							{
+								clientPlayerEntity.sendMessage(Text.translatable("cfx.error.not_executing_as_player_direction_changed").formatted(Formatting.RED), false);
+								setScreen(null);
+								return;
+							}
+							else if (world.getBlockEntity(blockHitResult.getBlockPos(), type).isEmpty())
+							{
+								clientPlayerEntity.sendMessage(Text.translatable("cfx.error.not_executing_as_sign_broke").formatted(Formatting.RED), false);
+								setScreen(null);
+								return;
+							}
+
+							// Zero tolerance for changes
+							SignBlockEntity sign2 = (SignBlockEntity) world.getBlockEntity(blockHitResult.getBlockPos());
+							List<String> commands2 = Arrays.stream(Objects.requireNonNull(sign2).getText(sign2.isPlayerFacingFront(clientPlayerEntity))
+									.getMessages(clientPlayerEntity.shouldFilterText())).filter(text -> text.getStyle().getClickEvent() != null
+									&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).toList();
+
+							if (!commands.equals(commands2))
+							{
+								clientPlayerEntity.sendMessage(Text.translatable("cfx.error.not_executing_as_sign_changed").formatted(Formatting.RED), false);
+								setScreen(null);
+								return;
+							}
+
+							original.call(instance, clientPlayerEntity, hand, blockHitResult);
+						}
+						setScreen(null);
+					}, Text.translatable("cfx.prompt.run_command" + (commands.size() > 1 ? "s" : "")),
+							Text.literal(String.join("\n", commands))));
+
+					return ActionResult.SUCCESS;
+				}
+				case DO_NOTHING ->
+				{
+					return ActionResult.FAIL;
+				}
+				default ->
+				{
+					return original.call(instance, clientPlayerEntity, hand, blockHitResult);
+				}
+			}
+		}
+		else
+		{
+			return original.call(instance, clientPlayerEntity, hand, blockHitResult);
+		}
+	}
+}

--- a/v1_20/src/main/resources/cfx.v1_20.mixins.json
+++ b/v1_20/src/main/resources/cfx.v1_20.mixins.json
@@ -9,9 +9,10 @@
   },
   "mixins": [
     "BadSherdIdentifiers",
-    "ClickableCommandSign"
+    "CommandSigns"
   ],
   "client": [
+    "CommandSignsTwo",
     "ExcessiveHearts"
   ]
 }

--- a/v1_20_3/src/main/resources/cfx.v1_20_3.mixins.json
+++ b/v1_20_3/src/main/resources/cfx.v1_20_3.mixins.json
@@ -13,7 +13,5 @@
     "ComponentDepthTwo",
     "InvalidHeadURL",
     "OutrageousTranslation"
-  ],
-  "client": [
   ]
 }

--- a/v1_21_2/src/main/java/me/videogamesm12/cfx/v1_21_2/patches/CommandSignsTwo.java
+++ b/v1_21_2/src/main/java/me/videogamesm12/cfx/v1_21_2/patches/CommandSignsTwo.java
@@ -1,0 +1,115 @@
+package me.videogamesm12.cfx.v1_21_2.patches;
+
+import com.llamalad7.mixinextras.injector.wrapoperation.Operation;
+import com.llamalad7.mixinextras.injector.wrapoperation.WrapOperation;
+import me.videogamesm12.cfx.CFX;
+import me.videogamesm12.cfx.management.PatchMeta;
+import net.minecraft.block.entity.BlockEntityType;
+import net.minecraft.block.entity.SignBlockEntity;
+import net.minecraft.client.MinecraftClient;
+import net.minecraft.client.gui.screen.ConfirmScreen;
+import net.minecraft.client.gui.screen.Screen;
+import net.minecraft.client.network.ClientPlayerEntity;
+import net.minecraft.client.network.ClientPlayerInteractionManager;
+import net.minecraft.client.world.ClientWorld;
+import net.minecraft.text.ClickEvent;
+import net.minecraft.text.Text;
+import net.minecraft.util.ActionResult;
+import net.minecraft.util.Formatting;
+import net.minecraft.util.Hand;
+import net.minecraft.util.hit.BlockHitResult;
+import org.jetbrains.annotations.Nullable;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+@Mixin(MinecraftClient.class)
+@PatchMeta(minVersion = 768, maxVersion = 999)
+public abstract class CommandSignsTwo
+{
+	@Shadow @Nullable public ClientWorld world;
+
+	@Shadow public abstract void setScreen(Screen par1);
+
+	@WrapOperation(method= "doItemUse", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/network/ClientPlayerInteractionManager;interactBlock(Lnet/minecraft/client/network/ClientPlayerEntity;Lnet/minecraft/util/Hand;Lnet/minecraft/util/hit/BlockHitResult;)Lnet/minecraft/util/ActionResult;"))
+	public ActionResult verify(ClientPlayerInteractionManager instance, ClientPlayerEntity clientPlayerEntity, Hand hand,
+							   BlockHitResult blockHitResult, Operation<ActionResult> original)
+	{
+		if (world != null && world.getBlockEntity(blockHitResult.getBlockPos()) != null
+				&& world.getBlockEntity(blockHitResult.getBlockPos()) instanceof SignBlockEntity sign
+				&& sign.getText(sign.isPlayerFacingFront(clientPlayerEntity)).hasRunCommandClickEvent(clientPlayerEntity))
+		{
+			switch (CFX.getConfig().getTextPatches().getClickEvent().getCommandClickClientMode())
+			{
+				case NOTIFY ->
+				{
+					final List<String> commands = Arrays.stream(sign.getText(sign.isPlayerFacingFront(clientPlayerEntity)).getMessages(clientPlayerEntity.shouldFilterText())).filter(text -> text.getStyle().getClickEvent() != null
+							&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).toList();
+
+					// This is the deal as we knew it when we clicked the sign.
+					final BlockEntityType<?> type = sign.getType();
+					final boolean playerIsFacingFront = sign.isPlayerFacingFront(clientPlayerEntity);
+
+					setScreen(new ConfirmScreen((bool) -> {
+						if (bool)
+						{
+							// -- Integrity checks to prevent switcheroos --
+
+							// We will refuse to execute if:
+							//	* The player is no longer facing the sign in question
+							// 	* The sign is not loaded or no longer exists
+							//	* The commands on the side of the sign have since changed
+							if (playerIsFacingFront != sign.isPlayerFacingFront(clientPlayerEntity))
+							{
+								clientPlayerEntity.sendMessage(Text.translatable("cfx.error.not_executing_as_player_direction_changed").formatted(Formatting.RED), false);
+								setScreen(null);
+								return;
+							}
+							else if (world.getBlockEntity(blockHitResult.getBlockPos(), type).isEmpty())
+							{
+								clientPlayerEntity.sendMessage(Text.translatable("cfx.error.not_executing_as_sign_broke").formatted(Formatting.RED), false);
+								setScreen(null);
+								return;
+							}
+
+							// Zero tolerance for changes
+							SignBlockEntity sign2 = (SignBlockEntity) world.getBlockEntity(blockHitResult.getBlockPos());
+							List<String> commands2 = Arrays.stream(Objects.requireNonNull(sign2).getText(sign2.isPlayerFacingFront(clientPlayerEntity))
+									.getMessages(clientPlayerEntity.shouldFilterText())).filter(text -> text.getStyle().getClickEvent() != null
+									&& text.getStyle().getClickEvent().getAction() == ClickEvent.Action.RUN_COMMAND).map(text -> text.getStyle().getClickEvent().getValue()).toList();
+
+							if (!commands.equals(commands2))
+							{
+								clientPlayerEntity.sendMessage(Text.translatable("cfx.error.not_executing_as_sign_changed").formatted(Formatting.RED), false);
+								setScreen(null);
+								return;
+							}
+
+							original.call(instance, clientPlayerEntity, hand, blockHitResult);
+						}
+						setScreen(null);
+					}, Text.translatable("cfx.prompt.run_command" + (commands.size() > 1 ? "s" : "")),
+							Text.literal(String.join("\n", commands))));
+
+					return ActionResult.SUCCESS;
+				}
+				case DO_NOTHING ->
+				{
+					return ActionResult.FAIL;
+				}
+				default ->
+				{
+					return original.call(instance, clientPlayerEntity, hand, blockHitResult);
+				}
+			}
+		}
+		else
+		{
+			return original.call(instance, clientPlayerEntity, hand, blockHitResult);
+		}
+	}
+}

--- a/v1_21_2/src/main/resources/cfx.v1_21_2.mixins.json
+++ b/v1_21_2/src/main/resources/cfx.v1_21_2.mixins.json
@@ -8,6 +8,7 @@
     "defaultRequire": 1
   },
   "client": [
+    "CommandSignsTwo",
     "ExcessiveEntityNames"
   ]
 }


### PR DESCRIPTION
### Explanation
CommandSigns has the ability to trick unsuspecting users into clicking a sign and executing commands on the server-side which bypassed any checks that the patches that ClickableCommands had, since all the command executions were done server-side. A solution was proven to be needed after an incident on a non-Fabric server I manage in which a disruptive player was able to trick a staff member into executing a command which stopped the server using a sign.

### Implementation
This introduces a "part 2" of sorts for the CommandSigns patch for the client side which by default prompts the user for confirmation before an interact with a sign with the "run_command" click event on one or more of the lines goes through to the server.

![AV21aQw22zLs](https://github.com/user-attachments/assets/7457e27d-b849-4941-bfd8-1cc18984d892)

Since there is no configuration changes (the patch just re-uses the configuration entry for ClickableCommands), the mod configuration version remains the same.

### Pending Potential Polishing
This is relegated to a pull request as I investigate a better way of implementing this.